### PR TITLE
[DATA] Implement zero-copied string dtype and accelerate shuffle.

### DIFF
--- a/hybridbackend/tensorflow/benchmarks/data_benchmark_tfrecord.py
+++ b/hybridbackend/tensorflow/benchmarks/data_benchmark_tfrecord.py
@@ -38,19 +38,46 @@ def benchmark(params):
     tf.logging.info('Started generating mock file ...')
     workspace = tempfile.mkdtemp()
     params.filenames = [os.path.join(workspace, 'benchmark.tfrecord')]
-    df = pd.DataFrame(
-      np.random.randint(
-        0, 100,
-        size=(params.batch_size * 100, len(params.fields)),
-        dtype=np.int64),
-      columns=params.fields)
+    if params.use_string_data:
+      df = pd.DataFrame(
+        np.array([
+          [
+            *[
+              np.array(list(map(str, np.random.randint(
+                0, 9,
+                size=(np.random.randint(10, 30),),
+                dtype=np.int64))))
+              for _ in xrange(len(params.fields))]]
+          for _ in xrange(params.batch_size * 100)], dtype=object),
+        columns=params.fields)
+    elif params.use_fixed_len_string_data:
+      df = pd.DataFrame(
+        np.array([
+          ['abcdefghijklmnoprstu' for _ in xrange(len(params.fields))]
+          for _ in xrange(params.batch_size * 100)], dtype=np.str),
+        columns=params.fields)
+    else:
+      df = pd.DataFrame(
+        np.random.randint(
+          0, 100,
+          size=(params.batch_size * 100, len(params.fields)),
+          dtype=np.int64),
+        columns=params.fields)
     writer = tf.python_io.TFRecordWriter(params.filenames[0])
-    for row in tq(range(params.samples)):
-      feats = tf.train.Features(
-        feature={
-          f: tf.train.Feature(
-            int64_list=tf.train.Int64List(value=[df[f][row]]))
-          for f in params.fields})
+    for row in tq(range(params.batch_size * 100)):
+      if params.use_string_data or params.use_fixed_len_string_data:
+        feats = tf.train.Features(
+          feature={
+            f: tf.train.Feature(
+              bytes_list=tf.train.BytesList(
+                value=[bytes(val, 'utf-8') for val in df[f][row]]))
+            for f in params.fields})
+      else:
+        feats = tf.train.Features(
+          feature={
+            f: tf.train.Feature(
+              int64_list=tf.train.Int64List(value=[df[f][row]]))
+            for f in params.fields})
       example = tf.train.Example(features=feats)
       writer.write(example.SerializeToString())
     writer.close()
@@ -58,19 +85,42 @@ def benchmark(params):
   with tf.Graph().as_default():
     step = tf.train.get_or_create_global_step()
     ds = tf.data.TFRecordDataset(params.filenames)
+    if params.shuffle:
+      ds = ds.shuffle(params.batch_size * 10)
     ds = ds.batch(params.batch_size, drop_remainder=True)
-    ds = ds.map(
-      lambda line: tf.parse_example(
-        line, {f: tf.FixedLenFeature([1], tf.int64) for f in params.fields}))
+    if params.use_string_data or params.use_fixed_len_string_data:
+      ds = ds.map(
+        lambda line: tf.parse_example(
+          line, {f: tf.VarLenFeature(tf.string) for f in params.fields}))
+    else:
+      ds = ds.map(
+        lambda line: tf.parse_example(
+          line, {f: tf.FixedLenFeature([1], tf.int64) for f in params.fields}))
     batch = tf.data.make_one_shot_iterator(ds).get_next()
-    train_op = tf.group(batch + [step.assign_add(1)])
-    with tf.train.MonitoredTrainingSession('') as sess:
+    train_op = tf.group(list(batch.values()) + [step.assign_add(1)])
+    chief_only_hooks = []
+    if params.profile_every_n_iter is not None:
+      chief_only_hooks.append(
+        tf.train.ProfilerHook(
+          save_steps=params.profile_every_n_iter,
+          output_dir=params.output_dir))
+    with tf.train.MonitoredTrainingSession(
+        '', chief_only_hooks=chief_only_hooks) as sess:
       count = 0
       prev_ts = time.time()
       try:
-        while not sess.should_stop():
-          sess.run(train_op)
-          count += 1
+        with tq() as pbar:
+          should_stop = False
+          while not sess.should_stop() and not should_stop:
+            prev_sess_run = time.time()
+            sess.run(train_op)
+            sess_run_duration = time.time() - prev_sess_run
+            pbar.set_description(
+              f'{params.batch_size / sess_run_duration:6.2f} samples/sec')
+            pbar.update(1)
+            count += 1
+            if params.num_steps is not None:
+              should_stop = count >= params.num_steps
       except tf.errors.OutOfRangeError:
         pass
       duration = time.time() - prev_ts
@@ -87,7 +137,14 @@ if __name__ == '__main__':
   os.environ['CUDA_VISIBLE_DEVICES'] = ''
   tf.logging.set_verbosity(tf.logging.INFO)
   parser = argparse.ArgumentParser()
+  parser.add_argument('--shuffle', default=False, action='store_true')
+  parser.add_argument('--use-string-data', default=False, action='store_true')
+  parser.add_argument(
+    '--use-fixed-len-string-data', default=False, action='store_true')
   parser.add_argument('--batch-size', type=int, default=64000)
+  parser.add_argument('--num-steps', type=int, default=None)
+  parser.add_argument('--output-dir', default='./outputs')
+  parser.add_argument('--profile-every-n-iter', type=int, default=None)
   parser.add_argument(
     '--fields', nargs='+', default=[f'f{c}' for c in xrange(200)])
   parser.add_argument('filenames', nargs='*')

--- a/hybridbackend/tensorflow/data/rebatch/buffer.h
+++ b/hybridbackend/tensorflow/data/rebatch/buffer.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <vector>
 
 #include <tensorflow/core/framework/tensor.h>
+#include <tensorflow/core/lib/core/threadpool.h>
 #include <tensorflow/core/lib/random/philox_random.h>
 #include <tensorflow/core/lib/random/random.h>
 #include <tensorflow/core/lib/random/random_distributions.h>
@@ -29,9 +30,16 @@ namespace hybridbackend {
 
 struct RebatchBufferItem {
  public:
-  RebatchBufferItem(int64 batch_size, const std::vector<Tensor>& components)
-      : batch_size(batch_size), components(components) {}
+  RebatchBufferItem(int64 batch_size, const std::vector<int64>& start,
+                    const std::vector<int64>& limit,
+                    const std::vector<Tensor>& components)
+      : batch_size(batch_size),
+        start(start),
+        limit(limit),
+        components(components) {}
   int64 batch_size;
+  std::vector<int64> start;
+  std::vector<int64> limit;
   std::vector<Tensor> components;
 };
 
@@ -54,6 +62,11 @@ class RebatchBuffer {
   Status Take(Allocator* alloc, std::vector<Tensor>* output_tensors,
               const int64 num_rows);
 
+  Status FastPath(Allocator* alloc, const std::vector<Tensor>& input_tensors,
+                  std::vector<Tensor>* output_tensors);
+
+  Status CheckZeroCopiedString(const std::vector<Tensor>& input_tensors);
+
  private:
   Status TakeDense(Allocator* alloc, std::vector<Tensor>* output_tensors,
                    std::vector<Tensor>* residual_tensors, const int64 num_rows,
@@ -70,7 +83,10 @@ class RebatchBuffer {
   const std::vector<int32> field_ranks_;
 
   int64 size_;
-  std::deque<RebatchBufferItem> items_;
+  std::vector<std::unique_ptr<RebatchBufferItem>> items_;
+  std::shared_ptr<thread::ThreadPool> takers_;
+  std::vector<int32> field_cols_;
+  std::vector<bool> has_zerocopied_string_;
 };
 
 }  // namespace hybridbackend

--- a/hybridbackend/tensorflow/data/rebatch/rebatch_buffer.cc
+++ b/hybridbackend/tensorflow/data/rebatch/rebatch_buffer.cc
@@ -14,6 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include <tensorflow/core/framework/register_types.h>
+#include <tensorflow/core/framework/tensor_description.pb.h>
 #include <tensorflow/core/public/version.h>
 
 #include <algorithm>
@@ -21,6 +22,7 @@ limitations under the License.
 #include <vector>
 
 #include "hybridbackend/common/env.h"
+#include "hybridbackend/tensorflow/common/arrow.h"
 #include "hybridbackend/tensorflow/common/eigen.h"
 #include "hybridbackend/tensorflow/data/rebatch/buffer.h"
 
@@ -133,15 +135,60 @@ RebatchBuffer::RebatchBuffer(
     : output_dtypes_(output_dtypes),
       output_shapes_(output_shapes),
       field_ranks_(field_ranks),
-      size_(0) {}
+      size_(0) {
+  const int kArrowNumThreads =
+      ::hybridbackend::EnvVarGetInt("ARROW_NUM_THREADS", 16);
+  takers_.reset(new thread::ThreadPool(
+      Env::Default(), ThreadOptions(), "rebatch_buffer_takers",
+      kArrowNumThreads, true /* low_latency_hint */));
+  int32 col = 0;
+  for (int64 rank : field_ranks_) {
+    field_cols_.emplace_back(col);
+    col += (rank + 1);
+  }
+
+  has_zerocopied_string_.reserve(output_dtypes_.size());
+}
+
+Status RebatchBuffer::CheckZeroCopiedString(
+    const std::vector<Tensor>& input_tensors) {
+  has_zerocopied_string_.resize(input_tensors.size());
+  auto work = [&](int64 begin, int64 end) {
+    for (int64 i = begin; i < end; ++i) {
+      if (input_tensors[i].dtype() != DT_STRING) {
+        has_zerocopied_string_[i] = false;
+      } else {
+        ::tensorflow::TensorDescription tensor_description;
+        input_tensors[i].FillDescription(&tensor_description);
+        if (tensor_description.has_allocation_description() &&
+            tensor_description.allocation_description().allocator_name() ==
+                "ZerocopyArrowStringTensorBuffer") {
+          has_zerocopied_string_[i] = true;
+        } else {
+          has_zerocopied_string_[i] = false;
+        }
+      }
+    }
+  };
+  const int64 cost_per_unit = 20;
+  takers_->ParallelFor(input_tensors.size(), cost_per_unit, work);
+  return Status::OK();
+}
 
 Status RebatchBuffer::Put(const std::vector<Tensor>& input_tensors,
                           const int64 num_rows) {
   if (TF_PREDICT_FALSE(num_rows == 0)) {
     return Status::OK();
   }
-
-  items_.emplace_back(num_rows, input_tensors);
+  std::vector<int64> start(output_dtypes_.size(), 0);
+  std::vector<int64> limit(output_dtypes_.size(), num_rows);
+  for (int i = 0; i < input_tensors.size(); ++i) {
+    if (has_zerocopied_string_[i]) {
+      limit[i] = input_tensors[i].NumElements();
+    }
+  }
+  items_.emplace_back(absl::make_unique<RebatchBufferItem>(
+      num_rows, start, limit, std::move(input_tensors)));
   size_ += num_rows;
   return Status::OK();
 }
@@ -153,32 +200,51 @@ Status RebatchBuffer::PutSlice(const std::vector<Tensor>& input_tensors,
   }
 
   std::vector<Tensor> sliced_input_tensors(output_dtypes_.size());
-  int64 col = 0;
-  for (int64 rank : field_ranks_) {
-    int64 start = row_start;
-    int64 limit = row_limit;
-    if (rank != 0) {
-      for (size_t split_idx = 1; split_idx < rank + 1; ++split_idx) {
-        auto split_slice =
-            input_tensors[col + split_idx].Slice(start, (limit + 1));
-        const int64 slice_limit = (limit - start);
-        start = split_slice.unaligned_flat<int32>()(0);
-        limit = split_slice.unaligned_flat<int32>()(slice_limit);
-        sliced_input_tensors[col + split_idx] = std::move(split_slice);
+  std::vector<int64> start_pos(output_dtypes_.size());
+  std::vector<int64> limit_pos(output_dtypes_.size());
+
+  auto work = [&](int64 begin, int64 end) {
+    for (int64 i = begin; i < end; ++i) {
+      int rank = field_ranks_[i];
+      int col = field_cols_[i];
+      int64 start = row_start;
+      int64 limit = row_limit;
+      if (rank != 0) {
+        for (size_t split_idx = 1; split_idx < rank + 1; ++split_idx) {
+          auto split_slice =
+              input_tensors[col + split_idx].Slice(start, (limit + 1));
+          const int64 slice_limit = (limit - start);
+          start = split_slice.unaligned_flat<int32>()(0);
+          limit = split_slice.unaligned_flat<int32>()(slice_limit);
+          sliced_input_tensors[col + split_idx] = std::move(split_slice);
+          start_pos[col + split_idx] = start;
+          limit_pos[col + split_idx] = limit;
+        }
+      }
+      const auto input_shape = input_tensors[col].shape();
+      int64 input_base_elems = 1;
+      if (TF_PREDICT_FALSE(input_shape.dims() > 1)) {
+        input_base_elems = input_shape.num_elements() / input_shape.dim_size(0);
+      }
+      if (!has_zerocopied_string_[col]) {
+        sliced_input_tensors[col] = input_tensors[col].Slice(
+            start / input_base_elems, limit / input_base_elems);
+        start_pos[col] = start / input_base_elems;
+        limit_pos[col] = limit / input_base_elems;
+      } else {
+        sliced_input_tensors[col] = input_tensors[col];
+        start_pos[col] = start;
+        limit_pos[col] = limit;
       }
     }
-    const auto input_shape = input_tensors[col].shape();
-    int64 input_base_elems = 1;
-    if (TF_PREDICT_FALSE(input_shape.dims() > 1)) {
-      input_base_elems = input_shape.num_elements() / input_shape.dim_size(0);
-    }
-    sliced_input_tensors[col] = input_tensors[col].Slice(
-        start / input_base_elems, limit / input_base_elems);
-    col += (rank + 1);
-  }
+    return Status::OK();
+  };
+  const int64 cost_per_unit = 20;
+  takers_->ParallelFor(field_ranks_.size(), cost_per_unit, work);
 
   const int64 num_rows = row_limit - row_start;
-  items_.emplace_back(num_rows, std::move(sliced_input_tensors));
+  items_.emplace_back(absl::make_unique<RebatchBufferItem>(
+      num_rows, start_pos, limit_pos, std::move(sliced_input_tensors)));
   size_ += num_rows;
   return Status::OK();
 }
@@ -212,11 +278,11 @@ Status RebatchBuffer::Take(Allocator* alloc,
   int64 remained_rows = 0;
   int64 num_dirty_rows = 0;
   for (int64 row = 0; num_dirty_rows < items_.size(); ++num_dirty_rows) {
-    if (row + items_[num_dirty_rows].batch_size > num_rows) {
+    if (row + items_[num_dirty_rows]->batch_size > num_rows) {
       remained_rows = (num_rows - row);
       break;
     }
-    row += items_[num_dirty_rows].batch_size;
+    row += items_[num_dirty_rows]->batch_size;
   }
 
   const size_t num_components = output_dtypes_.size();
@@ -224,30 +290,70 @@ Status RebatchBuffer::Take(Allocator* alloc,
   output_tensors->resize(num_components);
   std::vector<Tensor> residual_tensors;
   residual_tensors.resize(num_components);
-  int64 col = 0;
-  for (int64 rank : field_ranks_) {
-    if (rank == 0) {
-      TF_RETURN_IF_ERROR(TakeDense(alloc, output_tensors, &residual_tensors,
-                                   num_rows, remained_rows, rank, col));
-    } else {
-      TF_RETURN_IF_ERROR(TakeSparse(alloc, output_tensors, &residual_tensors,
-                                    num_rows, remained_rows, rank, col));
-    }
-    col += (rank + 1);
-  }
 
-  for (int64 idx = 0; idx < num_dirty_rows; ++idx) {
-    items_.pop_front();
-  }
+  auto work = [&](int64 begin, int64 end) {
+    for (int64 i = begin; i < end; ++i) {
+      if (field_ranks_[i] == 0) {
+        TF_RETURN_IF_ERROR(TakeDense(alloc, output_tensors, &residual_tensors,
+                                     num_rows, remained_rows, field_ranks_[i],
+                                     field_cols_[i]));
+      } else {
+        TF_RETURN_IF_ERROR(TakeSparse(alloc, output_tensors, &residual_tensors,
+                                      num_rows, remained_rows, field_ranks_[i],
+                                      field_cols_[i]));
+      }
+    }
+    return Status::OK();
+  };
+  const int64 cost_per_unit = 200;
+  takers_->ParallelFor(field_ranks_.size(), cost_per_unit, work);
+  items_.erase(items_.begin(), items_.begin() + num_dirty_rows);
+
   if (remained_rows > 0) {
-    int64 residual_rows = items_.front().batch_size - remained_rows;
-    items_.pop_front();
+    int64 residual_rows = items_.front()->batch_size - remained_rows;
     if (residual_rows > 0) {
-      items_.emplace_front(residual_rows, std::move(residual_tensors));
+      items_.front()->components = residual_tensors;
+      items_.front()->batch_size = residual_rows;
+    } else {
+      items_.erase(items_.begin());
     }
   }
 
   size_ -= num_rows;
+  return Status::OK();
+}
+
+Status RebatchBuffer::FastPath(Allocator* alloc,
+                               const std::vector<Tensor>& input_tensors,
+                               std::vector<Tensor>* output_tensors) {
+  auto work = [&](int64 begin, int64 end) {
+    for (int i = begin; i < end; ++i) {
+      if (!has_zerocopied_string_[i]) {
+        output_tensors->at(i) = input_tensors[i];
+      } else {
+        output_tensors->at(i) =
+            Tensor(alloc, input_tensors[i].dtype(), input_tensors[i].shape());
+        if (!output_tensors->at(i).IsInitialized()) {
+          return errors::ResourceExhausted(
+              "Failed to allocate memory for output component ", i);
+        }
+        auto output_tensor_ptr = output_tensors->at(i).vec<std::string>();
+        auto input_string_buf =
+            reinterpret_cast<ArrowStringTensorBuffer*>(input_tensors[i].data());
+        for (int j = 0; j < input_tensors[i].NumElements(); ++j) {
+          int string_size;
+          auto string_data = input_string_buf->GetValue(j, &string_size);
+          output_tensor_ptr(j).assign(
+              reinterpret_cast<const char*>(string_data), string_size);
+        }
+      }
+    }
+    return Status::OK();
+  };
+
+  const int64 cost_per_unit = 200;
+  takers_->ParallelFor(input_tensors.size(), cost_per_unit, work);
+
   return Status::OK();
 }
 
@@ -269,21 +375,56 @@ Status RebatchBuffer::TakeDense(Allocator* alloc,
 
   // Populate output
   for (int64 idx = 0, row = 0; idx < items_.size(); ++idx) {
-    auto& item = items_[idx].components[col];
-    if (row + items_[idx].batch_size > num_rows) {
+    auto& item = items_[idx]->components[col];
+    if (row + items_[idx]->batch_size > num_rows) {
       if (remained_rows == 0) {
         break;
       }
-      auto sliced_input = item.Slice(0, remained_rows);
-      TF_RETURN_IF_ERROR(CopyToSlicesFromTensor(&(output_tensors->at(col)), row,
-                                                std::move(sliced_input), true));
-      (*residual_tensors)[col] =
-          item.Slice(remained_rows, items_[idx].batch_size);
+
+      if (!has_zerocopied_string_[col]) {
+        auto sliced_input = item.Slice(0, remained_rows);
+        TF_RETURN_IF_ERROR(CopyToSlicesFromTensor(
+            &(output_tensors->at(col)), row, std::move(sliced_input), true));
+        (*residual_tensors)[col] =
+            item.Slice(remained_rows, items_[idx]->batch_size);
+        items_[idx]->start[col] = remained_rows;
+      } else {
+        int64 start = items_[idx]->start[col];
+        int64 limit = start + remained_rows;
+        auto output_tensor_ptr = output_tensors->at(col).vec<std::string>();
+        auto item_string_buf_ptr =
+            reinterpret_cast<ArrowStringTensorBuffer*>(item.data());
+        for (int i = start; i < limit; ++i) {
+          int64 output_idx = row + i - start;
+          int string_size;
+          auto string_data = item_string_buf_ptr->GetValue(i, &string_size);
+          output_tensor_ptr(output_idx)
+              .assign(reinterpret_cast<const char*>(string_data), string_size);
+        }
+        (*residual_tensors)[col] = item;
+        items_[idx]->start[col] = limit;
+      }
       break;
     }
-    TF_RETURN_IF_ERROR(
-        CopyToSlicesFromTensor(&(output_tensors->at(col)), row, item, true));
-    row += items_[idx].batch_size;
+    if (!has_zerocopied_string_[col]) {
+      TF_RETURN_IF_ERROR(
+          CopyToSlicesFromTensor(&(output_tensors->at(col)), row, item, true));
+    } else {
+      // populating string type of output tensors
+      int64 item_start_pos = items_[idx]->start[col];
+      int64 item_limit_pos = items_[idx]->limit[col];
+      auto output_tensor_ptr = output_tensors->at(col).vec<std::string>();
+      auto item_string_buf_ptr =
+          reinterpret_cast<ArrowStringTensorBuffer*>(item.data());
+      for (int i = item_start_pos; i < item_limit_pos; ++i) {
+        int64 output_idx = row + i - item_start_pos;
+        int string_size;
+        auto string_data = item_string_buf_ptr->GetValue(i, &string_size);
+        output_tensor_ptr(output_idx)
+            .assign(reinterpret_cast<const char*>(string_data), string_size);
+      }
+    }
+    row += items_[idx]->batch_size;
   }
 
   return Status::OK();
@@ -301,15 +442,15 @@ Status RebatchBuffer::TakeSparse(Allocator* alloc,
     int64 next_remained_dim0_size = 0;
     int64 dim0_size = 0;
     for (int64 idx = 0, row = 0; idx < items_.size(); ++idx) {
-      if (row + items_[idx].batch_size > num_rows) {
+      if (row + items_[idx]->batch_size > num_rows) {
         next_remained_dim0_size =
-            items_[idx].components[col + split_idx].unaligned_flat<int32>()(
+            items_[idx]->components[col + split_idx].unaligned_flat<int32>()(
                 remained_dim0_size - 1);
         dim0_size += (remained_dim0_size - 1);
         break;
       }
-      dim0_size += (items_[idx].components[col + split_idx].dim_size(0) - 1);
-      row += items_[idx].batch_size;
+      dim0_size += (items_[idx]->components[col + split_idx].dim_size(0) - 1);
+      row += items_[idx]->batch_size;
     }
 
     PartialTensorShape split_pshape(output_shapes_[col + split_idx]);
@@ -326,11 +467,11 @@ Status RebatchBuffer::TakeSparse(Allocator* alloc,
     (*output_tensors)[col + split_idx].unaligned_flat<int32>()(0) = 0;
     int64 dim0_index = 0;
     for (int64 idx = 0, row = 0; idx < items_.size(); ++idx) {
-      auto& split = items_[idx].components[col + split_idx];
+      auto& split = items_[idx]->components[col + split_idx];
       int32 output_last = output_tensors->at(col + split_idx)
                               .unaligned_flat<int32>()(dim0_index);
       int32 input_first = split.unaligned_flat<int32>()(0);
-      if (row + items_[idx].batch_size > num_rows) {
+      if (row + items_[idx]->batch_size > num_rows) {
         if (remained_rows == 0) {
           break;
         }
@@ -360,7 +501,7 @@ Status RebatchBuffer::TakeSparse(Allocator* alloc,
           sliced_output_split.unaligned_flat<int32>().constant(output_last -
                                                                input_first);
       dim0_index += sliced_input_split.dim_size(0);
-      row += items_[idx].batch_size;
+      row += items_[idx]->batch_size;
     }
 
     remained_dim0_size = next_remained_dim0_size;
@@ -369,11 +510,17 @@ Status RebatchBuffer::TakeSparse(Allocator* alloc,
   // Create and populate ouput values
   int64 values_dim0_size = 0;
   for (int64 idx = 0, row = 0; idx < items_.size(); ++idx) {
-    if (row + items_[idx].batch_size > num_rows) {
+    int64 item_start_pos = items_[idx]->start[col];
+    int64 item_limit_pos = items_[idx]->limit[col];
+    if (row + items_[idx]->batch_size > num_rows) {
       break;
     }
-    values_dim0_size += items_[idx].components[col].dim_size(0);
-    row += items_[idx].batch_size;
+    if (!has_zerocopied_string_[col]) {
+      values_dim0_size += items_[idx]->components[col].dim_size(0);
+    } else {
+      values_dim0_size += (item_limit_pos - item_start_pos);
+    }
+    row += items_[idx]->batch_size;
   }
   PartialTensorShape base_pshape(output_shapes_[col]);
   base_pshape.set_dim(0, 1);
@@ -392,8 +539,11 @@ Status RebatchBuffer::TakeSparse(Allocator* alloc,
 
   int64 dim0_index = 0;
   for (int64 idx = 0, row = 0; idx < items_.size(); ++idx) {
-    auto& values = items_[idx].components[col];
-    if (row + items_[idx].batch_size > num_rows) {
+    auto& values = items_[idx]->components[col];
+    int64 item_start_pos = items_[idx]->start[col];
+    int64 item_limit_pos = items_[idx]->limit[col];
+
+    if (row + items_[idx]->batch_size > num_rows) {
       if (remained_rows == 0) {
         break;
       }
@@ -403,20 +553,55 @@ Status RebatchBuffer::TakeSparse(Allocator* alloc,
         values_base_elems =
             values_shape.num_elements() / values_shape.dim_size(0);
       }
-      auto sliced_values =
-          values.Slice(0, remained_dim0_size / values_base_elems);
-      TF_RETURN_IF_ERROR(
-          CopyToSlicesFromTensor(&(output_tensors->at(col)), dim0_index,
-                                 std::move(sliced_values), true));
-      (*residual_tensors)[col] = values.Slice(
-          remained_dim0_size / values_base_elems, values.dim_size(0));
+      if (!has_zerocopied_string_[col]) {
+        auto sliced_values =
+            values.Slice(0, remained_dim0_size / values_base_elems);
+        TF_RETURN_IF_ERROR(
+            CopyToSlicesFromTensor(&(output_tensors->at(col)), dim0_index,
+                                   std::move(sliced_values), true));
+        (*residual_tensors)[col] = values.Slice(
+            remained_dim0_size / values_base_elems, values.dim_size(0));
+      } else {
+        int64 start = items_[idx]->start[col];
+        int64 limit = start + remained_dim0_size;
+        auto output_tensor_ptr = output_tensors->at(col).vec<std::string>();
+        auto item_string_buf_ptr =
+            reinterpret_cast<ArrowStringTensorBuffer*>(values.data());
+        for (int i = start; i < limit; ++i) {
+          int64 output_idx = dim0_index + i - start;
+          int string_size;
+          auto string_data = item_string_buf_ptr->GetValue(i, &string_size);
+          output_tensor_ptr(output_idx)
+              .assign(reinterpret_cast<const char*>(string_data), string_size);
+        }
+        (*residual_tensors)[col] = values;
+        items_[idx]->start[col] = limit;
+      }
       break;
     }
 
-    TF_RETURN_IF_ERROR(CopyToSlicesFromTensor(&(output_tensors->at(col)),
-                                              dim0_index, values, true));
-    dim0_index += values.dim_size(0);
-    row += items_[idx].batch_size;
+    if (!has_zerocopied_string_[col]) {
+      TF_RETURN_IF_ERROR(CopyToSlicesFromTensor(&(output_tensors->at(col)),
+                                                dim0_index, values, true));
+    } else {
+      auto output_tensor_ptr = output_tensors->at(col).vec<std::string>();
+      auto item_string_buf_ptr =
+          reinterpret_cast<ArrowStringTensorBuffer*>(values.data());
+      for (int i = item_start_pos; i < item_limit_pos; ++i) {
+        int64 output_idx = dim0_index + i - item_start_pos;
+        int string_size;
+        auto string_data = item_string_buf_ptr->GetValue(i, &string_size);
+        output_tensor_ptr(output_idx)
+            .assign(reinterpret_cast<const char*>(string_data), string_size);
+      }
+    }
+
+    if (!has_zerocopied_string_[col]) {
+      dim0_index += values.dim_size(0);
+    } else {
+      dim0_index += (item_limit_pos - item_start_pos);
+    }
+    row += items_[idx]->batch_size;
   }
 
   return Status::OK();


### PR DESCRIPTION
1. Implement a zero-copied approach to read string data from Arrow to TF.
2. Accelerate the shuffle operation of string type in ParquetDataset.

preliminary benchmarking results
- col=300, `batch_size`=1000
- `Intel(R) Xeon(R) Platinum 8369B CPU @ 2.90GHz` with 128 logical cores.

| Dataset            | list type | shuffling | throughput (samples/s) | speedup over TFRecord |
| ---                | ---       | ---       | ---                    | ---                   |
| TFRecord           | N         | N         | 1404.23                | 1.0                   |
| HbParquet          | N         | N         | 41137.53               | 29.3                  |
| HbParquet-ZeroCopy | N         | N         | 51335.40               | 36.56                 |
| TFRecord           | N         | Y         | 1343.10                | 1.0                   |
| HbParquet          | N         | Y         | 6629.60                | 4.9                   |
| HbParquet-ZeroCopy | N         | Y         | 10941.25               | 8.1                   |
| TFRecord           | Y         | N         | 1352.05                | 1.0                   |
| HbParquet          | Y         | N         | 2307.33                | 1.71                  |
| HbParquet-ZeroCopy | Y         | N         | 2869.98                | 2.12                  |
| TFRecord           | Y         | Y         | 1367.96                | 1.0                   |
| HbParquet          | Y         | Y         | 1080.03                | 0.79                  |
| HbParquet-ZeroCopy | Y         | Y         | 1454.02                | 1.06                  |